### PR TITLE
Fix access_token refresh bug

### DIFF
--- a/tuya_connector/openapi.py
+++ b/tuya_connector/openapi.py
@@ -145,7 +145,7 @@ class TuyaOpenAPI:
             return
 
         self.token_info.access_token = ""
-        response = self.post(
+        response = self.get(
             TO_B_REFRESH_TOKEN_API.format(self.token_info.refresh_token)
         )
 


### PR DESCRIPTION
Hi, there's a bug in `__refresh_access_token_if_need` method in `openapi.py`.
Refresh token API need to be called with GET method, not POST.
https://developer.tuya.com/en/docs/cloud/80bb968f1d?id=Ka7kjv3j8jgvr