### PR TITLE
adjustment in the openpulsar library to use "Subscription Management"…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ The `tuya-connector-python` SDK is designed to support openAPIs and Pulsar messa
    # Call any API from Tuya
    response = openapi.get("/v1.0/statistics-datas-survey", dict())
    
-   # Init Message Queue
+   # Init Message Queue with subscription management
    open_pulsar = TuyaOpenPulsar(
-   	ACCESS_ID, ACCESS_KEY, MQ_ENDPOINT, TuyaCloudPulsarTopic.PROD
+   	ACCESS_ID, ACCESS_KEY, MQ_ENDPOINT, TuyaCloudPulsarTopic.PROD, suffix="sub"
    )
+   
    # Add Message Queue listener
    open_pulsar.add_message_listener(lambda msg: print(f"---\nexample receive: {msg}"))
    

--- a/tuya_connector/openpulsar.py
+++ b/tuya_connector/openpulsar.py
@@ -40,7 +40,8 @@ class TuyaOpenPulsar(threading.Thread):
                  access_id: str,
                  access_secret: str,
                  ws_endpoint: str,
-                 topic: str):
+                 topic: str,
+                 suffix: str = "sub"):
         """Init TuyaOpenPulsar."""
         threading.Thread.__init__(self)
         self._stop_event = threading.Event()
@@ -50,6 +51,8 @@ class TuyaOpenPulsar(threading.Thread):
         self.__access_secret = access_secret
         self.__ws_endpoint = ws_endpoint
         self.__topic = topic
+
+        self.suffix = suffix
 
         self.message_listeners = set()
 
@@ -86,7 +89,7 @@ class TuyaOpenPulsar(threading.Thread):
         return self.__ws_endpoint + "ws/v2/consumer/persistent/"\
             + self.__access_id + "/out/"\
             + self.__topic + "/"\
-            + self.__access_id + "-sub"\
+            + self.__access_id + "-" + self.suffix\
             + WEB_SOCKET_QUERY_PARAMS
 
     def __message_handler(self, payload):


### PR DESCRIPTION
When using openpulsar with the new pulsar function "Subscription Management" I noticed that the suffixes used by the Client ID were not working. I made a small change to the library to allow passing the suffix when instantiating the class.

EX:
open_pulsar = TuyaOpenPulsar(
     ACCESS_ID, ACCESS_KEY, MQ_ENDPOINT, TuyaCloudPulsarTopic.PROD, suffix="sub"
)